### PR TITLE
Various improvments

### DIFF
--- a/plugin/GOD.vim
+++ b/plugin/GOD.vim
@@ -58,4 +58,4 @@ endfun
 " Command {{{
 command! -nargs=+ -complete=help GOD call <SID>GetOnlineDoc(<f-args>)
 " }}}
-" vim:fdm=marker
+" vim:fdm=marker:sw=4:

--- a/plugin/GOD.vim
+++ b/plugin/GOD.vim
@@ -51,18 +51,7 @@ endfunction
 " Encode url
 function! s:URLEncode(str) abort
     " Replace each non hex character of the string by its hex representation
-    let l:new = ''
-
-    for l:i in range(1, strlen(a:str))
-        let l:c = a:str[l:i - 1]
-
-        if l:c =~ '\w'
-            let l:new .= l:c
-        else
-            let l:new .= printf('%%%02x', char2nr(l:c))
-        endif
-    endfor
-
+    let l:new = join(map(range(0, strlen(a:str)-1), 'a:str[v:val] =~ "\\w" ? a:str[v:val] : printf("%%%02x", char2nr(a:str[v:val]))'), '')
     return l:new
 endfun
 " }}}

--- a/plugin/GOD.vim
+++ b/plugin/GOD.vim
@@ -10,11 +10,7 @@ endif
 
 let loaded_god_vim = 1
 
-if exists("g:god_close_help_buffer")
-    let s:god_close_help_buffer = 1
-else
-    let s:god_close_help_buffer = 0
-endif
+let s:god_close_help_buffer = get(g:, 'god_close_help_buffer', 0)
 " }}}
 " Functions {{{
 " Get a link to the online page of an help tag

--- a/plugin/GOD.vim
+++ b/plugin/GOD.vim
@@ -10,11 +10,12 @@ endif
 
 let loaded_god_vim = 1
 
-let s:god_close_help_buffer = get(g:, 'god_close_help_buffer', 0)
 " }}}
 " Functions {{{
 " Get a link to the online page of an help tag
 function! s:GetOnlineDoc(...) abort
+    let l:god_close_help_buffer = get(g:, 'god_close_help_buffer', 0)
+
     let l:result = ''
 
     for topic in a:000
@@ -28,7 +29,7 @@ function! s:GetOnlineDoc(...) abort
         let l:link        = "[`:h ". l:tag ."`](http://vimhelp.appspot.com/". l:file .".html#". l:tagEncoded .")"
 
         " Optional, close the opened help file
-        if s:god_close_help_buffer
+        if l:god_close_help_buffer
             execute "bd"
         endif
 

--- a/plugin/GOD.vim
+++ b/plugin/GOD.vim
@@ -30,7 +30,7 @@ function! s:GetOnlineDoc(...) abort
 
         " Optional, close the opened help file
         if l:god_close_help_buffer
-            execute "bd"
+            bd
         endif
 
         if len(a:000) == 1


### PR DESCRIPTION
In order to simplify the process I've created only one PR. You may not be interested in the performances optimizations -- not everybody prefer `map()` over `:for`.

I haven't removed the useless `l:` prefixes. I know some coding standards requires them. As far as I'm concerned, I don't prefix my local variables in C, C++, Python, etc. Why should I do the same in VimL? It's a cognitive burden I'd rather avoid. The only cases it really makes a difference is when we want to have UpperCamelCase variable names (which is required to handle Funcref).

On a similar topic, I don't know if you're aware that `<SID>` prefix is required in only one context: to define mappings that call script-local functions which are defined where the mappings are defined. Moreover `<sid>` messes up searching with the _star_ (`*`) when `'isk'` contains `:`. IOW, I use `<sid>` only when I have no choice.